### PR TITLE
Localize new session fields

### DIFF
--- a/app/views/trestle/auth/sessions/new.html.erb
+++ b/app/views/trestle/auth/sessions/new.html.erb
@@ -10,14 +10,14 @@
   <div class="form-group">
     <div class="input-group">
       <span class="input-group-addon"><i class="fa fa-user fa-fw"></i></span>
-      <%= text_field_tag Trestle.config.auth.authenticate_with, "", placeholder: Trestle.config.auth.authenticate_with.to_s.humanize, class: "form-control" %>
+      <%= text_field_tag Trestle.config.auth.authenticate_with, "", placeholder: t("activerecord.attributes.#{Trestle.config.auth.user_class.to_s.downcase}.#{Trestle.config.auth.authenticate_with}", default: Trestle.config.auth.authenticate_with.to_s.humanize), class: "form-control" %>
     </div>
   </div>
 
   <div class="form-group">
     <div class="input-group">
       <span class="input-group-addon"><i class="fa fa-lock fa-fw"></i></span>
-      <%= password_field_tag :password, "", placeholder: "Password", class: "form-control" %>
+      <%= password_field_tag :password, "", placeholder: t("activerecord.attributes.#{Trestle.config.auth.user_class.to_s.downcase}.password", default: "Password"), class: "form-control" %>
     </div>
   </div>
 


### PR DESCRIPTION
Hi ! I'm not really sure if it's the best way to do this, but it would be nice to be able to localize these fields ; and I think it's better to use the table's attributes instead of new fields on `admin.auth`.