### PR TITLE
dont raise an exception if the before_actions are not defined

### DIFF
--- a/app/controllers/trestle/auth/sessions_controller.rb
+++ b/app/controllers/trestle/auth/sessions_controller.rb
@@ -1,8 +1,8 @@
 class Trestle::Auth::SessionsController < Trestle::ApplicationController
   layout 'trestle/auth'
 
-  skip_before_action :authenticate_user, only: [:new, :create]
-  skip_before_action :require_authenticated_user
+  skip_before_action :authenticate_user, only: [:new, :create], raise: false
+  skip_before_action :require_authenticated_user, raise: false
 
   def new
   end


### PR DESCRIPTION
This fixes an error when using a custom controller and not defining either of the before filters