### PR TITLE
Pass local variables f in login form params

### DIFF
--- a/app/views/trestle/auth/sessions/_form.html.erb
+++ b/app/views/trestle/auth/sessions/_form.html.erb
@@ -16,7 +16,7 @@
   </div>
 </div>
 
-<%= hook("auth.login.form") %>
+<%= hook("auth.login.form", f) %>
 
 <% if Trestle.config.auth.remember.enabled %>
 <div class="form-group">


### PR DESCRIPTION
This change is needed to pass the form instance to the partial rendered inside trestle-auth-otp. This way I can add the otp params to the object