### PR TITLE
CI fixes

### DIFF
--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -9,6 +9,7 @@ end
 
 gem "rails", "~> 6.0.0"
 gem "sprockets-rails"
+gem "turbo-rails", "2.0.7"
 gem "sqlite3", "~> 1.4"
 gem "devise"
 

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -9,6 +9,7 @@ end
 
 gem "rails", "~> 6.1.0"
 gem "sprockets-rails"
+gem "turbo-rails", "2.0.7"
 gem "sqlite3", "~> 1.4"
 gem "devise"
 


### PR DESCRIPTION
Temporarily pin turbo-rails to 2.0.7 for Ruby 2.6 / Rails 6.x tests
